### PR TITLE
fix: preserve HTTPS scheme in TRUSTED_ORIGINS config

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -291,12 +291,15 @@ func serveAnalytics(
 	}
 
 	// Transform domain strings to full URLs for CSRF middleware
-	trustedOriginURLs := make([]string, 0, len(trustedOrigins))
+	trustedOriginURLs := make([]string, 0, len(trustedOrigins)*2)
 	for _, domain := range trustedOrigins {
-		if !strings.HasPrefix(domain, "http://") && !strings.HasPrefix(domain, "https://") {
-			trustedOriginURLs = append(trustedOriginURLs, "http://"+domain)
-		} else {
+		if strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://") {
+			// Already has scheme - use as-is
 			trustedOriginURLs = append(trustedOriginURLs, domain)
+		} else {
+			// Legacy: no scheme stored - trust both protocols for backward compatibility
+			trustedOriginURLs = append(trustedOriginURLs, "http://"+domain)
+			trustedOriginURLs = append(trustedOriginURLs, "https://"+domain)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,9 +141,7 @@ func parseTrustedOrigins(originsStr string) []string {
 	for _, part := range parts {
 		origin := strings.TrimSpace(part)
 		origin = strings.ToLower(origin)
-		// Strip protocol if provided
-		origin = strings.TrimPrefix(origin, "http://")
-		origin = strings.TrimPrefix(origin, "https://")
+		// Keep scheme if provided (required for CSRF validation)
 		origin = strings.TrimSuffix(origin, "/")
 
 		if origin != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -126,3 +126,59 @@ data_dir = "./config-data"
 	assert.True(t, cfg.SecureCookies)
 	assert.Equal(t, []string{"example.com", "foo.test"}, cfg.TrustedOrigins)
 }
+
+func TestParseTrustedOrigins(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "single domain without scheme",
+			input:    "example.com",
+			expected: []string{"example.com"},
+		},
+		{
+			name:     "preserves https scheme",
+			input:    "https://example.com",
+			expected: []string{"https://example.com"},
+		},
+		{
+			name:     "preserves http scheme",
+			input:    "http://example.com",
+			expected: []string{"http://example.com"},
+		},
+		{
+			name:     "multiple origins with mixed schemes",
+			input:    "https://secure.example.com, http://insecure.test, plain.domain",
+			expected: []string{"https://secure.example.com", "http://insecure.test", "plain.domain"},
+		},
+		{
+			name:     "strips trailing slashes",
+			input:    "https://example.com/",
+			expected: []string{"https://example.com"},
+		},
+		{
+			name:     "lowercases origins",
+			input:    "HTTPS://Example.COM",
+			expected: []string{"https://example.com"},
+		},
+		{
+			name:     "trims whitespace",
+			input:    "  https://example.com  ,  http://test.com  ",
+			expected: []string{"https://example.com", "http://test.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseTrustedOrigins(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
The TRUSTED_ORIGINS env var was stripping the scheme (http/https) during parsing, then blindly reconstructing with http:// for CSRF validation.

fixes: #87
