### PR TITLE
feat: add goals CRUD API

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -525,6 +525,12 @@ func serveAnalytics(
 		})
 	})
 
+	// Goals API (protected)
+	app.Get("/api/goals/:website_id", middleware.Auth, handlers.HandleGoalList)
+	app.Post("/api/goals", middleware.Auth, handlers.HandleGoalCreate)
+	app.Put("/api/goals/:id", middleware.Auth, handlers.HandleGoalUpdate)
+	app.Delete("/api/goals/:id", middleware.Auth, handlers.HandleGoalDelete)
+
 	// Start server
 	port := getEnv("PORT", "3000")
 	logging.L().Info("starting kaunta server", zap.String("port", port))

--- a/internal/database/migrations/000014_add_goals.down.sql
+++ b/internal/database/migrations/000014_add_goals.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS goals;

--- a/internal/database/migrations/000014_add_goals.up.sql
+++ b/internal/database/migrations/000014_add_goals.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS goals (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    website_id UUID NOT NULL REFERENCES website(website_id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    target_url TEXT,
+    target_event TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(website_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_goals_website_id ON goals(website_id);

--- a/internal/handlers/goals.go
+++ b/internal/handlers/goals.go
@@ -1,0 +1,119 @@
+package handlers
+
+import (
+	"context"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/seuros/kaunta/internal/database"
+	"github.com/seuros/kaunta/internal/models"
+)
+
+// HandleGoalList → GET /api/goals/:website_id
+func HandleGoalList(c fiber.Ctx) error {
+	websiteID := c.Params("website_id")
+	if _, err := uuid.Parse(websiteID); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid website_id"})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	rows, err := database.DB.QueryContext(ctx,
+		`SELECT id, website_id, name, target_url, target_event, created_at, updated_at
+		 FROM goals
+		 WHERE website_id = $1
+		 ORDER BY created_at DESC`, websiteID)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "database error"})
+	}
+	defer func() { _ = rows.Close() }()
+
+	var goals []models.Goal
+	for rows.Next() {
+		var g models.Goal
+		if err := rows.Scan(&g.ID, &g.WebsiteID, &g.Name, &g.TargetURL, &g.TargetEvent, &g.CreatedAt, &g.UpdatedAt); err != nil {
+			return c.Status(500).JSON(fiber.Map{"error": "scan error"})
+		}
+		goals = append(goals, g)
+	}
+
+	if err := rows.Err(); err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "rows error"})
+	}
+
+	return c.JSON(goals)
+}
+
+// HandleGoalCreate   → POST /api/goals
+func HandleGoalCreate(c fiber.Ctx) error {
+	var req struct {
+		WebsiteID   string  `json:"website_id" validate:"required,uuid4"`
+		Name        string  `json:"name" validate:"required"`
+		TargetURL   *string `json:"target_url"`
+		TargetEvent *string `json:"target_event"`
+	}
+	if err := c.Bind().JSON(&req); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid payload"})
+	}
+
+	id := uuid.New().String()
+	_, err := database.DB.Exec(
+		`INSERT INTO goals (id, website_id, name, target_url, target_event, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, NOW(), NOW())`,
+		id, req.WebsiteID, req.Name, req.TargetURL, req.TargetEvent)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to create goal"})
+	}
+
+	return c.Status(201).JSON(models.Goal{
+		ID:          id,
+		WebsiteID:   req.WebsiteID,
+		Name:        req.Name,
+		TargetURL:   req.TargetURL,
+		TargetEvent: req.TargetEvent,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	})
+}
+
+// HandleGoalUpdate   → PUT  /api/goals/:id
+func HandleGoalUpdate(c fiber.Ctx) error {
+	id := c.Params("id")
+	if _, err := uuid.Parse(id); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid goal id"})
+	}
+
+	var req struct {
+		Name        *string `json:"name"`
+		TargetURL   *string `json:"target_url"`
+		TargetEvent *string `json:"target_event"`
+	}
+	if err := c.Bind().JSON(&req); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid payload"})
+	}
+
+	_, err := database.DB.Exec(
+		`UPDATE goals SET name = COALESCE($1, name), target_url = $2, target_event = $3, updated_at = NOW()
+		 WHERE id = $4`,
+		req.Name, req.TargetURL, req.TargetEvent, id)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "update failed"})
+	}
+	return c.SendStatus(200)
+}
+
+// HandleGoalDelete   → DELETE /api/goals/:id
+func HandleGoalDelete(c fiber.Ctx) error {
+	id := c.Params("id")
+	if _, err := uuid.Parse(id); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid goal id"})
+	}
+
+	_, err := database.DB.Exec(`DELETE FROM goals WHERE id = $1`, id)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "delete failed"})
+	}
+	return c.SendStatus(204)
+}

--- a/internal/handlers/goals_test.go
+++ b/internal/handlers/goals_test.go
@@ -1,0 +1,123 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/google/uuid"
+	"github.com/seuros/kaunta/internal/database"
+	"github.com/seuros/kaunta/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleGoalList_Success(t *testing.T) {
+	websiteID := uuid.New().String()
+	goalID1 := uuid.New().String()
+	goalID2 := uuid.New().String()
+	now := time.Now()
+
+	responses := []mockResponse{
+		{
+			match:   "SELECT id, website_id, name, target_url, target_event, created_at, updated_at FROM goals WHERE website_id = $1",
+			args:    []interface{}{websiteID},
+			columns: []string{"id", "website_id", "name", "target_url", "target_event", "created_at", "updated_at"},
+			rows: [][]interface{}{
+				{goalID1, websiteID, "Signup Goal", "/signup", nil, now, now},
+				{goalID2, websiteID, "Purchase Goal", nil, "purchase", now, now},
+			},
+		},
+	}
+
+	queue := newMockQueue(responses)
+	driverName, err := registerMockDriver(queue)
+	require.NoError(t, err)
+
+	db, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	original := database.DB
+	database.DB = db
+	defer func() { database.DB = original }()
+
+	app := fiber.New()
+	app.Get("/api/goals/:website_id", HandleGoalList)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/goals/"+websiteID, nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var goals []models.Goal
+	err = json.NewDecoder(resp.Body).Decode(&goals)
+	require.NoError(t, err)
+	assert.Len(t, goals, 2)
+	assert.Equal(t, "Signup Goal", goals[0].Name)
+
+	require.NoError(t, queue.expectationsMet())
+}
+
+func TestHandleGoalList_InvalidWebsiteID(t *testing.T) {
+	app := fiber.New()
+	app.Get("/api/goals/:website_id", HandleGoalList)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/goals/invalid-uuid", nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Equal(t, "invalid website_id", result["error"])
+}
+
+func TestHandleGoalList_DatabaseError(t *testing.T) {
+	websiteID := uuid.New().String()
+	responses := []mockResponse{
+		{
+			match: "SELECT id, website_id, name, target_url, target_event, created_at, updated_at FROM goals WHERE website_id = $1",
+			args:  []interface{}{websiteID},
+			err:   assert.AnError,
+		},
+	}
+
+	queue := newMockQueue(responses)
+	driverName, err := registerMockDriver(queue)
+	require.NoError(t, err)
+
+	db, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	original := database.DB
+	database.DB = db
+	defer func() { database.DB = original }()
+
+	app := fiber.New()
+	app.Get("/api/goals/:website_id", HandleGoalList)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/goals/"+websiteID, nil)
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	var result map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Equal(t, "database error", result["error"])
+
+	require.NoError(t, queue.expectationsMet())
+}

--- a/internal/models/goal.go
+++ b/internal/models/goal.go
@@ -1,0 +1,14 @@
+package models
+
+import "time"
+
+// Goal represents a conversion goal
+type Goal struct {
+	ID          string    `json:"id" db:"id"`
+	WebsiteID   string    `json:"website_id" db:"website_id"`
+	Name        string    `json:"name" db:"name"`
+	TargetURL   *string   `json:"target_url,omitempty" db:"target_url"`
+	TargetEvent *string   `json:"target_event,omitempty" db:"target_event"`
+	CreatedAt   time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at" db:"updated_at"`
+}


### PR DESCRIPTION
- Add goals table and migration
- Add Goal model with string UUIDs
- Add protected CRUD endpoints (/api/goals)
- Add unit test for goals handler